### PR TITLE
fix(.gitignore): Update .gitignore to include JDTLS specific files and directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,14 @@
+# Ignore Intellij Idea specific files
+.idea
+
+# Ignore Echlipse LSP (JDTLS) specific files
+.settings
+.project
+.classpath
+
 # Ignore Gradle project-specific cache directory
 .gradle
-.idea
+
 # Ignore Gradle build output directory
 build
+bin


### PR DESCRIPTION
The Echlipse LSP (JDTLS) generates a lot of files and directories when it runs for the first time. This commit adds them to the `.gitignore` file so that they get ignored from now on. The commit also organizes the structure of the `.gitignore` file.