### PR TITLE
Feat (backend): Parse recorded/uploaded audio file.

### DIFF
--- a/app/src/main/java/org/orpheus/ProcessAudio.java
+++ b/app/src/main/java/org/orpheus/ProcessAudio.java
@@ -4,8 +4,9 @@ import java.io.*;
 import javax.sound.sampled.*;
 
 public class ProcessAudio {
-  private static final AudioFormat TARGET_FORMAT = new AudioFormat(AudioFormat.Encoding.PCM_SIGNED, 11025f, 16, 1, 2,
-      11025, false);
+  private static final AudioFormat TARGET_FORMAT = new AudioFormat(AudioFormat.Encoding.PCM_SIGNED,
+      Constants.sampleRate, Constants.bitsPerSample, Constants.channelCount, Constants.bytesPerFrame,
+      Constants.framesPerSecond, false);
 
   public static double[] parse(String file) {
     try {
@@ -23,11 +24,15 @@ public class ProcessAudio {
 
       double[] samples = new double[totalFrames];
       for (int frame = 0, sampleIdx = 0; frame < totalFrames; ++frame) {
+        // convert to signed integer 0..255
         int low = streamBytes[sampleIdx] & 0xFF;
         int high = streamBytes[sampleIdx + 1] << 8;
+        // conbine all 16 bits
         int signed16 = high | low;
 
+        // singed16 is the signed 16bit PCM amplitude in range [-32768, +32767]
         samples[frame] = signed16 / 32768.0;
+        // hence, our sample contains doubles in range (-1..+1)
         sampleIdx += sampleSize * channelCount;
       }
 

--- a/app/src/main/java/org/orpheus/ProcessAudio.java
+++ b/app/src/main/java/org/orpheus/ProcessAudio.java
@@ -1,0 +1,40 @@
+package org.orpheus;
+
+import java.io.*;
+import javax.sound.sampled.*;
+
+public class ProcessAudio {
+  private static final AudioFormat TARGET_FORMAT = new AudioFormat(AudioFormat.Encoding.PCM_SIGNED, 11025f, 16, 1, 2,
+      11025, false);
+
+  public static double[] parse(String file) {
+    try {
+      AudioInputStream inputStream = AudioSystem.getAudioInputStream(new File(file));
+
+      AudioInputStream pcmStream = AudioSystem.getAudioInputStream(TARGET_FORMAT, inputStream);
+      inputStream.close();
+
+      byte[] streamBytes = pcmStream.readAllBytes();
+      pcmStream.close();
+
+      int sampleSize = TARGET_FORMAT.getSampleSizeInBits() / 8;
+      int channelCount = TARGET_FORMAT.getChannels();
+      int totalFrames = streamBytes.length / (sampleSize * channelCount);
+
+      double[] samples = new double[totalFrames];
+      for (int frame = 0, sampleIdx = 0; frame < totalFrames; ++frame) {
+        int low = streamBytes[sampleIdx] & 0xFF;
+        int high = streamBytes[sampleIdx + 1] << 8;
+        int signed16 = high | low;
+
+        samples[frame] = signed16 / 32768.0;
+        sampleIdx += sampleSize * channelCount;
+      }
+
+      return samples;
+    } catch (UnsupportedAudioFileException | IOException e) {
+      e.printStackTrace();
+      return null;
+    }
+  }
+}

--- a/app/src/main/java/org/orpheus/ProcessAudio.java
+++ b/app/src/main/java/org/orpheus/ProcessAudio.java
@@ -38,6 +38,7 @@ public class ProcessAudio {
 
       return samples;
     } catch (UnsupportedAudioFileException | IOException e) {
+      System.out.println("[ProcessAudio] ERROR: ");
       e.printStackTrace();
       return null;
     }

--- a/app/src/main/java/org/orpheus/RecordAudio.java
+++ b/app/src/main/java/org/orpheus/RecordAudio.java
@@ -54,6 +54,7 @@ public class RecordAudio {
           AudioSystem.write(inputStream, AudioFileFormat.Type.WAVE, this.outputFile);
 
         } catch (IOException e) {
+          System.out.println("[RecordAudio] ERROR: ");
           e.printStackTrace();
         }
       });
@@ -61,6 +62,7 @@ public class RecordAudio {
       this.recordingThread.start();
       System.out.println("Writing captured audio to disk now...");
     } catch (LineUnavailableException e) {
+      System.out.println("[RecordAudio] ERROR: ");
       e.printStackTrace();
     }
   }
@@ -77,6 +79,7 @@ public class RecordAudio {
     try {
       Thread.sleep(duration * 1000);
     } catch (InterruptedException e) {
+      System.out.println("[RecordAudio] ERROR: ");
       e.printStackTrace();
     }
 

--- a/app/src/main/java/org/orpheus/RecordAudio.java
+++ b/app/src/main/java/org/orpheus/RecordAudio.java
@@ -24,11 +24,11 @@ public class RecordAudio {
   }
 
   private AudioFormat getAudioFormat() {
-    float rate = 16000.0F;
-    int sizeInBits = 8;
-    int channels = 2;
+    float rate = 11025f;
+    int sizeInBits = 16;
+    int channels = 1;
     boolean signed = true;
-    boolean bigEndian = true;
+    boolean bigEndian = false;
 
     return new AudioFormat(rate, sizeInBits, channels, signed, bigEndian);
   }


### PR DESCRIPTION
`ProcessAudio::parse()` converts the audio file with given file path into the following format that is consistent to the FFT implementation. `class RecordAudio()` has been updated to match the new configuration.

- `11025` sample rate
- `PCM_SIGNED` encoding
- `16` bits per sample
- mono-channel

The method returns an array called `samples`, where each of its i<sup>th</sup> element, `sample[i]`, is the loudness/pressure of the audio at time = `i/11025`. In other words, if `samples[i]` is plotted on one axis and `i` on the other, the peaks and valleys of the audio can be seen in the waveframe.

This addresses the issue #19 (not finalized).